### PR TITLE
Revert removal of .env.example contents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+VUE_APP_AVA_IP=localhost
+VUE_APP_AVA_PORT=9650
+VUE_APP_AVA_PROTOCOL=http
+VUE_APP_NETWORK_ID=12345
+VUE_APP_CHAIN_ID=X
+VUE_APP_FAUCET_LINK=https://github.com/ava-labs/faucet-site


### PR DESCRIPTION
Following these instructions: https://medium.com/avalabs/the-ava-platform-tools-pt-1-the-ava-wallet-b2e849b57632 I found `.env.example` to be empty.  Considering the commit where it was changed: 3aec368 this looks like an accidental removal.